### PR TITLE
Add mysql data dir as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN service mysql start && \
     mysql -uroot -e "CREATE USER 'lychee'@'localhost' IDENTIFIED BY 'lychee';" && \
     mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO 'lychee'@'localhost' WITH GRANT OPTION;" && \
     mysql -uroot -e "FLUSH PRIVILEGES;"
+RUN mkdir /var/lib/mysql_init && \
+    mv /var/lib/mysql/* /var/lib/mysql_init
     
 # ------------------------------------------------------------------------------
 # Configure php-fpm
@@ -62,9 +64,11 @@ EXPOSE 80
 WORKDIR /
 RUN ln -s /var/www/lychee/uploads uploads 
 RUN ln -s /var/www/lychee/data data
+RUN ln -s /var/lib/mysql mysql
 
 VOLUME /uploads
 VOLUME /data
+VOLUME /mysql
 
 # ------------------------------------------------------------------------------
 # Add supervisord conf

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Download automated build from public Docker Hub Registry: docker pull kdelfour/l
 
     docker run -it -d -p 80:80 kdelfour/lychee-docker
     
-You can add a shared directory as a volume directory with the argument *-v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/* like this :
+You can add a shared directory as a volume directory with the argument *-v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/ -v /your-path/mysql/:/mysql/* like this :
 
-    docker run -it -d -p 80:80 -v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/ kdelfour/lychee-docker
+    docker run -it -d -p 80:80 -v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/ -v /your-path/mysql/:/mysql/ kdelfour/lychee-docker
 
 A mysql server with a database is ready, you can use it with this parameters : 
 
@@ -42,6 +42,6 @@ Build it
     
 And run
 
-    sudo docker run -d -p 80:80 -v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/ $USER/lychee-docker:latest
+    sudo docker run -d -p 80:80 -v /your-path/uploads/:/uploads/ -v /your-path/data/:/data/ -v /your-path/mysql/:/mysql/ $USER/lychee-docker:latest
     
 Enjoy !!    

--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -1,5 +1,5 @@
 [program:mysqld]
-command=/usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --user=mysql --log-error=/var/log/mysql/error.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306
+command=bash -c '( [ -e /var/lib/mysql/mysql ] || mv -n /var/lib/mysql_init/* /var/lib/mysql/ ) && /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --user=mysql --log-error=/var/log/mysql/error.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306'
 
 [program:nginx]
 command=/usr/sbin/nginx


### PR DESCRIPTION
The mysql data dir should be a volume so that the image metadata is not lost when recreating the container.