### PR TITLE
Run php5-fpm in foreground not confuse supervisord

### DIFF
--- a/conf/startup.conf
+++ b/conf/startup.conf
@@ -5,4 +5,4 @@ command=/usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/u
 command=/usr/sbin/nginx
 
 [program:php5-fpm]
-command=/usr/sbin/php5-fpm -c /etc/php5/fpm
+command=/usr/sbin/php5-fpm -F -c /etc/php5/fpm


### PR DESCRIPTION
When php5-fpm is started in background, the command exits after less than 1 second, which make supervisord think it failed and try to restart it several times.

Starting it in foreground fixes this and also makes supervisord take control over the process.