### PR TITLE
Removed php5-common duplicate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Kevin Delfour <kevin@delfour.eu>
 # Install base
 RUN apt-get update
 RUN apt-get install -yq wget git unzip nginx fontconfig-config fonts-dejavu-core \
-    php5-fpm php5-common php5-json php5-cli php5-common php5-mysql\
+    php5-fpm php5-common php5-json php5-cli php5-mysql\
     php5-gd php5-imagick php5-json php5-mcrypt php5-readline psmisc ssl-cert \
     ufw php-pear libgd-tools libmcrypt-dev mcrypt mysql-server mysql-client
 


### PR DESCRIPTION
`php5-common` was specified two times in the install command.