### PR TITLE
Create required subdirs under ../uploads/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ WORKDIR /var/www
 RUN git clone https://github.com/electerious/Lychee.git lychee
 RUN chown -R www-data:www-data /var/www/lychee
 RUN chmod -R 770 /var/www/lychee
-RUN chmod -R 777 /var/www/lychee/uploads/ 
+RUN mkdir /var/www/lychee/uploads/big /var/www/lychee/uploads/medium /var/www/lychee/uploads/thumb
+RUN chmod -R 777 /var/www/lychee/uploads/
+RUN chmod -R 777 /var/www/lychee/uploads/*
 RUN chmod -R 777 /var/www/lychee/data/
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
When starting this container 'out-of-the-box' I'm getting a permissions error while trying to upload images. 
The root cause is missing directories: 
/var/www/lychee/uploads/big /var/www/lychee/uploads/medium /var/www/lychee/uploads/thumb